### PR TITLE
add headless mode for token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,10 +428,13 @@ default_folder: Inbox
 default_signature: null       # set to signature name for auto-append
 timezone: UTC                 # output timezone for calendar commands (UTC, UTC+8, Asia/Shanghai)
 browser:
-  headless: false
+  headless: false             # headless applies to the automatic token refresh only
   timeout: 120
 output_format: table
 ```
+
+Set `browser.headless: true` to make the automatic token refresh reuse the saved OWA
+session without opening a browser window.
 
 Per-profile overrides are loaded from `~/.config/outlook-cli/accounts/<profile>/config.yaml` and are deep-merged on top of the global config.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,9 +14,10 @@ default_signature: null
 # See: https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones
 timezone: UTC
 
-# Browser settings for login
+# Browser settings for refresh
+# "outlook login" and "outlook account add" always show the browser window.
 browser:
-  headless: false
+  headless: false  # set to true to refresh the token without opening a window
   timeout: 120  # seconds to wait for login
 
 # Output format (table or json)

--- a/outlook_cli/auth.py
+++ b/outlook_cli/auth.py
@@ -19,6 +19,11 @@ from .exceptions import AccountError, AuthRequiredError, TokenExpiredError
 TOKEN_STORAGE_BACKEND = "keyring"
 TOKEN_STORAGE_VERSION = 1
 
+# A headless capture only has to wait for OWA to authenticate itself with the saved
+# cookies, so it must not stall a running command for as long as an interactive login.
+HEADLESS_CAPTURE_TIMEOUT = 30
+HEADED_CAPTURE_TIMEOUT = 120
+
 
 def get_token(account_name: str | None = None) -> str:
     """Return a valid bearer token for the selected account."""
@@ -44,6 +49,7 @@ def login(
     account_name: str | None = None,
     allow_create: bool = False,
     token: str | None = None,
+    headless: bool | None = None,
 ) -> str:
     """Authenticate and cache a bearer token.
 
@@ -53,6 +59,9 @@ def login(
         account_name: Account profile name
         allow_create: Allow creating new account profile
         token: Pre-fetched bearer token (skips browser if provided)
+        headless: Browser mode. None resolves it from the account's browser.headless
+            config, which is what the automatic token refresh does; interactive logins
+            pass False to force a visible window.
 
     Returns:
         Valid bearer token
@@ -78,10 +87,22 @@ def login(
     if not allow_create:
         account_service.ensure_account_known(selected)
 
+    use_headless = _resolve_headless(selected, headless)
+
     paths = account_service.get_account_paths(selected)
     paths.cache_dir.mkdir(parents=True, exist_ok=True)
     if not paths.uses_legacy_default:
         paths.config_dir.mkdir(parents=True, exist_ok=True)
+
+    # A headless capture depends entirely on the saved OWA cookies: without them the page
+    # stops at the Microsoft login form and no bearer token is ever issued. Bail out now
+    # instead of burning the whole capture timeout on a hopeless attempt.
+    if use_headless and not paths.browser_state_file.exists():
+        raise AuthRequiredError(
+            f"No saved browser session for account '{selected}'.\n"
+            "A headless token refresh needs an existing OWA session.\n"
+            "Run: outlook login"
+        )
 
     captured_token: list[str] = []
     seen_urls: list[str] = []
@@ -103,23 +124,28 @@ def login(
         if paths.browser_state_file.exists() and not force:
             launch_args["storage_state"] = str(paths.browser_state_file)
 
-        browser = p.chromium.launch(headless=False)
+        browser = p.chromium.launch(headless=use_headless)
         context = browser.new_context(user_agent=USER_AGENT, **launch_args)
         context.on("request", _intercept_request)
 
         page = context.new_page()
-        print("Opening Outlook... Log in and wait for your inbox to load.")
-        print("The browser will close automatically once the token is captured.")
+        if not use_headless:
+            print("Opening Outlook... Log in and wait for your inbox to load.")
+            print("The browser will close automatically once the token is captured.")
         page.goto(OWA_URL, wait_until="domcontentloaded")
 
-        deadline = time.time() + 120
+        # OWA does not reliably issue an authenticated API call on its own, so nudge it
+        # with a fetch. Headed logins get a grace period to let the user finish signing
+        # in; headless has nobody to wait for, so it nudges as soon as the page loads.
+        nudge_at = time.time() + (0 if use_headless else 25)
+        deadline = time.time() + (HEADLESS_CAPTURE_TIMEOUT if use_headless else HEADED_CAPTURE_TIMEOUT)
         while not captured_token and time.time() < deadline:
             try:
                 page.wait_for_timeout(2000)
             except Exception:
                 break
 
-            if not captured_token and time.time() > deadline - 95:
+            if not captured_token and time.time() > nudge_at:
                 try:
                     page.evaluate(
                         """
@@ -145,6 +171,12 @@ def login(
         print(f"\n  [debug] Total requests with Bearer: {len(seen_urls)}")
 
     if not captured_token:
+        if use_headless:
+            raise AuthRequiredError(
+                f"Could not refresh the token for account '{selected}' without a browser window.\n"
+                "The saved OWA session has most likely expired.\n"
+                "Run: outlook login"
+            )
         raise AuthRequiredError(
             "Could not capture bearer token.\n"
             "Make sure you logged in and your inbox fully loaded.\n"
@@ -158,6 +190,14 @@ def login(
     mailbox_info = account_service.bind_account(selected, me)
     _save_token(token, selected, mailbox_info)
     return token
+
+
+def _resolve_headless(account_name: str, headless: bool | None) -> bool:
+    """Resolve the browser mode: an explicit argument wins over the account config."""
+    if headless is not None:
+        return headless
+    browser_cfg = account_service.load_account_config(account_name).get("browser", {})
+    return bool(browser_cfg.get("headless", False))
 
 
 def _pick_best_token(tokens: list[str], debug: bool = False) -> str:

--- a/outlook_cli/commands/_common.py
+++ b/outlook_cli/commands/_common.py
@@ -199,6 +199,7 @@ def do_login(
     account_name: str | None = None,
     allow_create: bool = False,
     token: str | None = None,
+    headless: bool | None = None,
 ) -> str:
     selected = get_account_name(account_name, allow_missing=allow_create)
     return auth_login(
@@ -207,6 +208,7 @@ def do_login(
         account_name=selected,
         allow_create=allow_create,
         token=token,
+        headless=headless,
     )
 
 

--- a/outlook_cli/commands/account.py
+++ b/outlook_cli/commands/account.py
@@ -26,7 +26,7 @@ def add_account(name: str):
     if normalized in registry.get("accounts", {}):
         raise AccountError(f"Account profile '{normalized}' already exists.")
 
-    do_login(account_name=normalized, allow_create=True)
+    do_login(account_name=normalized, allow_create=True, headless=False)
     print_success(f"Account profile '{normalized}' added.")
 
 

--- a/outlook_cli/commands/auth.py
+++ b/outlook_cli/commands/auth.py
@@ -39,7 +39,7 @@ def login(force: bool, debug: bool, with_token: bool, account_name: str | None):
     import sys
 
     try:
-        login_kwargs = {"force": force, "debug": debug}
+        login_kwargs = {"force": force, "debug": debug, "headless": False}
         if account_name:
             login_kwargs["account_name"] = account_name
         if with_token:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "outlook365-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "Outlook 365 CLI — read, send, and manage emails from the terminal"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_account_commands.py
+++ b/tests/test_account_commands.py
@@ -17,7 +17,7 @@ def test_account_add_runs_login_without_switching_current(runner, tty_mode, monk
     result = runner.invoke(account_cmd.account, ["add", "work"])
 
     assert result.exit_code == 0
-    assert calls == [{"account_name": "work", "allow_create": True}]
+    assert calls == [{"account_name": "work", "allow_create": True, "headless": False}]
     assert messages == ["Account profile 'work' added."]
 
 

--- a/tests/test_common_cli_config.py
+++ b/tests/test_common_cli_config.py
@@ -41,7 +41,7 @@ def test_load_config_deep_merges_nested_values(tmp_path):
 
     assert cfg["max_messages"] == 50
     assert cfg["browser"]["timeout"] == 300
-    assert cfg["browser"]["headless"] is False
+    assert cfg["browser"]["headless"] is True
 
 
 def test_deep_merge_overrides_leaf_values():


### PR DESCRIPTION
The browser was hardcoded to headless=False, so every automatic token refresh popped a Chrome window in the middle of whatever command the user was running. A refresh does not need a UI: with a valid OWA session in browser-state.json, the token can be captured without one.

auth.login() takes headless: bool | None. None resolves from the account's browser.headless config, which is what the refresh paths do; outlook login and account add pass False so signing in always shows the window. The config key was already declared in DEFAULTS but never read by anything — it now governs the refresh. It stays false by default, so behaviour is unchanged unless you opt in.

A headless capture depends entirely on the saved OWA cookies, so it fails fast with "Run: outlook login" when browser-state.json is missing instead of burning the timeout, and it uses a short deadline rather than the 120s an interactive login needs. No silent fallback to a window.