### PR TITLE
Fix calendar timezone in table output

### DIFF
--- a/outlook_cli/commands/calendar.py
+++ b/outlook_cli/commands/calendar.py
@@ -219,7 +219,7 @@ def calendar(days: int, cal_name: str | None, as_json: bool, tz_str: str | None,
             print_success(f"No events in the {range_desc}.")
         else:
             console.print(f"[bold cyan]Calendar ({range_desc})[/bold cyan]")
-            print_events(events)
+            print_events(events, tz=tz)
 
 
 @click.command()
@@ -236,7 +236,7 @@ def event(event_id: str, as_json: bool, tz_str: str | None, account_name: str | 
     if _wants_json(as_json):
         click.echo(to_json_envelope(ev, tz=tz))
     else:
-        print_event_detail(ev)
+        print_event_detail(ev, tz=tz)
 
 
 @click.command("event-create")
@@ -459,7 +459,7 @@ def event_instances(event_id: str, days: int, as_json: bool, tz_str: str | None,
             print_success("No occurrences found.")
         else:
             console.print(f"[bold cyan]Occurrences ({len(events)})[/bold cyan]")
-            print_events(events)
+            print_events(events, tz=tz)
 
 
 @click.command("event-respond")

--- a/outlook_cli/formatter.py
+++ b/outlook_cli/formatter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 
 from rich import box
 from rich.console import Console
@@ -165,7 +165,8 @@ def print_attachments(attachments: list[Attachment]) -> None:
     console.print(table)
 
 
-def print_events(events: list[Event]) -> None:
+def print_events(events: list[Event], tz: tzinfo | None = None) -> None:
+    """Render events, converting their datetimes to ``tz`` when supplied."""
     table = _table(pad_edge=True)
     table.add_column("#", style="dim", width=5, justify="right")
     table.add_column("Date", width=12)
@@ -176,10 +177,12 @@ def print_events(events: list[Event]) -> None:
     table.add_column("Ppl", width=4, justify="right")
 
     for ev in events:
+        start = ev.start.astimezone(tz) if tz else ev.start
+        end = ev.end.astimezone(tz) if tz else ev.end
         table.add_row(
             str(ev.display_num) if ev.display_num else "",
-            ev.start.strftime("%Y-%m-%d"),
-            _event_time_text(ev),
+            start.strftime("%Y-%m-%d"),
+            _event_time_text(ev, start, end),
             _response_icon(ev.response_status),
             _truncate(ev.subject, 45),
             _truncate(ev.location, 20),
@@ -189,13 +192,16 @@ def print_events(events: list[Event]) -> None:
     console.print(table)
 
 
-def print_event_detail(event: Event) -> None:
+def print_event_detail(event: Event, tz: tzinfo | None = None) -> None:
+    """Render an event detail view in ``tz`` when supplied."""
+    start = event.start.astimezone(tz) if tz else event.start
+    end = event.end.astimezone(tz) if tz else event.end
     header = f"[bold]Subject:[/bold] {event.subject}\n"
     if event.is_all_day:
-        header += f"[bold]When:[/bold] {event.start.strftime('%Y-%m-%d')} (All day)\n"
+        header += f"[bold]When:[/bold] {start.strftime('%Y-%m-%d')} (All day)\n"
     else:
-        header += f"[bold]Start:[/bold] {event.start.strftime('%Y-%m-%d %H:%M')}\n"
-        header += f"[bold]End:[/bold] {event.end.strftime('%Y-%m-%d %H:%M')}\n"
+        header += f"[bold]Start:[/bold] {start.strftime('%Y-%m-%d %H:%M')}\n"
+        header += f"[bold]End:[/bold] {end.strftime('%Y-%m-%d %H:%M')}\n"
     if event.location:
         header += f"[bold]Location:[/bold] {event.location}\n"
     header += f"[bold]Organizer:[/bold] {event.organizer}\n"
@@ -433,10 +439,12 @@ def _flag_text(email: Email) -> Text:
     return flags
 
 
-def _event_time_text(event: Event) -> Text:
+def _event_time_text(event: Event, start: datetime | None = None, end: datetime | None = None) -> Text:
     if event.is_all_day:
         return Text("All Day", style="dim")
-    return Text(f"{event.start.strftime('%H:%M')}-{event.end.strftime('%H:%M')}", style="cyan")
+    start = start or event.start
+    end = end or event.end
+    return Text(f"{start.strftime('%H:%M')}-{end.strftime('%H:%M')}", style="cyan")
 
 
 def _response_icon(response_status: str) -> Text:

--- a/tests/test_commands_calendar.py
+++ b/tests/test_commands_calendar.py
@@ -45,6 +45,28 @@ def test_calendar_command_outputs_json(runner, tty_mode, monkeypatch, make_event
     assert payload["data"][0]["subject"] == "Standup"
 
 
+def test_calendar_command_converts_table_times_to_requested_timezone(runner, tty_mode, monkeypatch, make_event):
+    fake_client = type("Client", (), {})()
+    fake_client.get_calendar_view = lambda **_kwargs: [make_event()]
+    monkeypatch.setattr(calendar_cmd, "_get_client", lambda: fake_client)
+
+    result = runner.invoke(calendar_cmd.calendar, ["--days", "1", "--timezone", "UTC+2"])
+
+    assert result.exit_code == 0
+    assert "12:00-13:00" in result.output
+
+
+def test_event_command_converts_table_times_to_requested_timezone(runner, tty_mode, monkeypatch, make_event):
+    fake_client = type("Client", (), {})()
+    fake_client.get_event = lambda _event_id: make_event()
+    monkeypatch.setattr(calendar_cmd, "_get_client", lambda: fake_client)
+
+    result = runner.invoke(calendar_cmd.event, ["1", "--timezone", "UTC+2"])
+
+    assert result.exit_code == 0
+    assert "2026-03-17 12:00" in result.output
+
+
 def test_event_create_builds_recurrence_and_calls_client(runner, tty_mode, monkeypatch, make_event):
     fake_client = type("Client", (), {})()
     seen = {}


### PR DESCRIPTION
## Summary
- render calendar, event detail, and recurring-event tables in the timezone selected with `--timezone` or configured for the profile
- keep the existing JSON serialization behavior unchanged
- add regression coverage for calendar and event table output

## Root cause
The calendar commands resolved the requested timezone but only passed it to JSON serialization. Rich table renderers formatted the original UTC event datetimes directly.

## Validation
- `uv run --extra dev pytest` (262 passed, 6 skipped)
- `uv run --extra dev ruff check outlook_cli/formatter.py outlook_cli/commands/calendar.py tests/test_commands_calendar.py`